### PR TITLE
remove underline on hover on new external navbar links

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -243,6 +243,7 @@ const StyledExternalLink = styled(ExternalLink).attrs({
 
   :hover,
   :focus {
+    text-decoration: none;
     color: ${({ theme }) => darken(0.1, theme.text1)};
   }
 


### PR DESCRIPTION
PR #15 added external links to the Pangolin navbar, however they are underlined on hover which is inconsistent with the style of the other navbar links. This removes the underline on hover.