### PR TITLE
Update airdrop "claiming allowed" in real time

### DIFF
--- a/src/pages/Airdrop/index.tsx
+++ b/src/pages/Airdrop/index.tsx
@@ -5,7 +5,12 @@ import { TYPE } from '../../theme'
 import Card from '../../components/Card'
 import { ButtonError } from '../../components/Button'
 import { useIsTransactionPending } from '../../state/transactions/hooks'
-import { useClaimCallback, useUserHasAvailableClaim, useUserUnclaimedAmount } from '../../state/airdrop/hooks'
+import {
+	useAirdropIsClaimingAllowed,
+	useClaimCallback,
+	useUserHasAvailableClaim,
+	useUserUnclaimedAmount
+} from '../../state/airdrop/hooks'
 import { useActiveWeb3React } from '../../hooks'
 import Confetti from '../../components/Confetti'
 import { useTokenBalance } from '../../state/wallet/hooks'
@@ -62,6 +67,7 @@ export default function Vote() {
 	// monitor the status of the claim from contracts and txns
 	const { claimCallback } = useClaimCallback(account)
 
+	const claimingAllowed = useAirdropIsClaimingAllowed()
 	const canClaim = useUserHasAvailableClaim(account)
 
 	const claimAmount = useUserUnclaimedAmount(account)
@@ -101,7 +107,13 @@ export default function Vote() {
 			<TopSection gap="2px">
 				<Confetti start={Boolean(claimConfirmed)} />
 				<TYPE.mediumHeader style={{ margin: '0.5rem 0' }} textAlign="center">Claim PNG from Airdrop</TYPE.mediumHeader>
-				{!account ? (
+				{!claimingAllowed ? (
+					<Card padding="40px">
+						<TYPE.body color={theme.text3} textAlign="center">
+							The airdrop claim period has ended.
+						</TYPE.body>
+					</Card>
+				) : !account ? (
 					<Card padding="40px">
 						<TYPE.body color={theme.text3} textAlign="center">
 							Connect to a wallet to view your liquidity.

--- a/src/state/airdrop/hooks.ts
+++ b/src/state/airdrop/hooks.ts
@@ -7,6 +7,12 @@ import { TokenAmount, JSBI } from '@pangolindex/sdk'
 import { PNG } from './../../constants/index'
 import { useSingleCallResult } from '../multicall/hooks'
 
+export function useAirdropIsClaimingAllowed(): boolean {
+	const airdropContract = useAirdropContract()
+	const claimingAllowedResult = useSingleCallResult(airdropContract, 'claimingAllowed', [])
+	return Boolean(!claimingAllowedResult.loading && claimingAllowedResult.result != undefined && claimingAllowedResult.result[0] === true)
+}
+
 export function useUserHasAvailableClaim(account: string | null | undefined): boolean {
 	const airdropContract = useAirdropContract()
 	const withdrawAmountResult = useSingleCallResult(airdropContract, 'withdrawAmount', [account ? account : undefined])


### PR DESCRIPTION
Currently users who:

1) Were eligible for the airdrop
2) Did not claim their airdrop
3) Clicked a link to the airdrop

... will see a claim button upon viewing the airdrop page. Let's make sure nobody goes through any headaches trying to claim an airdrop that is no longer live.

This PR will query the liveness of an airdrop contract and only display the "Claim" button or other tutorials when the airdrop is currently live.