### PR TITLE
Whitelist available locales

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -16,6 +16,7 @@ i18next
     },
     fallbackLng: 'en',
     preload: ['en'],
+    whitelist: ['de', 'en', 'es-AR', 'es-US', 'it-IT', 'iw', 'ro', 'ru', 'vi', 'zh-CN', 'zh-TW'],
     keySeparator: false,
     interpolation: { escapeValue: false }
   })


### PR DESCRIPTION
When a browser has a locale not available from our IPFS, a request is still made to fetch ie. `en-US.json` and will occasionally stop the UI from loading until the request fails and we fallback to `en.json`

This avoids making requests for locales that have not been deployed to IPFS and will fallback to `en` immediately